### PR TITLE
Fixed Digikey provider so it looks for the id in product details instead of class

### DIFF
--- a/provider/digikey.py
+++ b/provider/digikey.py
@@ -36,7 +36,7 @@ def digikey2data(digi_pn):
 			req2 = urllib2.Request(digi_url, headers={'User-Agent' : "electronic-parser"})
 			page2 = urllib2.urlopen(req2)
 			soup2 = BeautifulSoup(page2.read(), 'html.parser')
-			u = soup2.find_all('table', class_='product-details')
+			u = soup2.find_all('table', id='product-details')
 
 			data = {
 				"provider": 'digikey',


### PR DESCRIPTION
The current provider tries to find product details using 'class' attribute on the <table> tag. It should be looking for 'id' attribute (as of this writing).